### PR TITLE
Fix: HTML parser import error in Python2.7

### DIFF
--- a/pws/bing.py
+++ b/pws/bing.py
@@ -1,5 +1,8 @@
 from bs4 import BeautifulSoup
-from html.parser import HTMLParser
+try:
+    from html.parser import HTMLParser
+except ImportError:
+    from HTMLParser import HTMLParser
 from time import sleep as wait
 import re
 import requests


### PR DESCRIPTION
html.parser is for Python3, HTMLParser is used in Python2.2 and above
adding try-except allows to use the module into Python2.7
